### PR TITLE
Changed install directory for 64-bit version

### DIFF
--- a/src/Makefile.vc6
+++ b/src/Makefile.vc6
@@ -12,9 +12,6 @@ USE_DEF_FILE = 1
 USE_LUA     = 0
 LUAJIT_ROOT = f:\MingW32\src\Parsers\LuaJIT
 
-LIB_TARGET = $(VCINSTALLDIR)lib
-BIN_TARGET = $(VCINSTALLDIR)bin
-
 #
 # Set '%WANT_64_BITS%=1' to build a 64-bit version. Adds a '_x64' suffix to
 # the DLL and lib.
@@ -23,9 +20,13 @@ BIN_TARGET = $(VCINSTALLDIR)bin
 X_SUFFIX = _x64
 MACHINE = x64
 BITNESS = 64
+LIB_TARGET = $(VCINSTALLDIR)lib\amd64
+BIN_TARGET = $(VCINSTALLDIR)bin\amd64
 !else
 MACHINE = x86
 BITNESS = 32
+LIB_TARGET = $(VCINSTALLDIR)lib
+BIN_TARGET = $(VCINSTALLDIR)bin
 !endif
 
 #
@@ -110,13 +111,13 @@ $(WSOCK_DLL) $(WSOCK_LIB): $(WSOCK_DEF) $(OBJECTS) $(DATA_OBJ) compile_juajit_$(
 	@del $(WSOCK_LIB:.lib=.exp)
 
 install:
-	copy $(WSOCK_LIB)               "$(LIB_TARGET)"
-	copy $(WSOCK_DLL)               "$(BIN_TARGET)"
+	copy $(WSOCK_LIB) "$(LIB_TARGET)"
+	copy $(WSOCK_DLL) "$(BIN_TARGET)"
 	copy wsock_trace$(X_SUFFIX).pdb "$(BIN_TARGET)"
 
 uninstall:
-	-del $(LIB_TARGET)\$(WSOCK_LIB)
-	-del $(BIN_TARGET)\$(WSOCK_DLL)
+	-del "$(LIB_TARGET)\$(WSOCK_LIB)"
+	-del "$(BIN_TARGET)\$(WSOCK_DLL)"
 
 geoip-gen4.c geoip-gen6.c: geoip.exe
 


### PR DESCRIPTION
Turns out that 64-bit link.exe (and 64-bit lib.exe) by default only look in dedicated "amd64" sub-folders of both the lib and bin directory for 64-bit libraries and DLLs. At least that's the case in VS2015. I think that's where the makefile should place them.

As an aside, the fact that 32 and 64 bit binaries don't end up in the same directory suggest the question of whether the "_64" suffix is even needed.
Currently I got this in my sources to easily link with dependancies:

```
#if (_MSC_VER)
#if (_DEBUG) && (WSOCK_TRACE)
#if (_WIN64)
#pragma comment (lib,"wsock_trace_x64")
#else
#pragma comment (lib,"wsock_trace")
#endif
#else
#pragma comment (lib,"ws2_32")
#endif /* (_DEBUG) && (WSOCK_TRACE) */
#endif
```

which could be shorten without the suffix to:

```
#if (_MSC_VER)
#if (_DEBUG) && (WSOCK_TRACE)
#pragma comment (lib,"wsock_trace")
#else
#pragma comment (lib,"ws2_32")
#endif /* (_DEBUG) && (WSOCK_TRACE) */
#endif
```
Just my opinion.

The white space I removed in the install target is for aesthetic reasons. It looks better when the commands are executed.

The quotes around the uninstall target are to escape possible spaces in the path.